### PR TITLE
C binding keywords

### DIFF
--- a/crystal-mode.el
+++ b/crystal-mode.el
@@ -55,7 +55,7 @@
   :group 'languages)
 
 (defconst crystal-block-beg-keywords
-  '("class" "module" "def" "if" "unless" "case" "while" "until" "for" "begin" "do" "macro")
+  '("class" "module" "def" "if" "unless" "case" "while" "until" "for" "begin" "do" "macro" "lib" "struct" "enum")
   "Keywords at the beginning of blocks.")
 
 (defconst crystal-block-beg-re
@@ -67,7 +67,7 @@
   "Regexp to match keywords that nest without blocks.")
 
 (defconst crystal-indent-beg-re
-  (concat "^\\(\\s *" (regexp-opt '("class" "module" "def" "macro")) "\\|"
+  (concat "^\\(\\s *" (regexp-opt '("class" "module" "def" "macro" "lib" "struct" "enum")) "\\|"
           (regexp-opt '("if" "unless" "case" "while" "until" "for" "begin"))
           "\\)\\_>")
   "Regexp to match where the indentation gets deeper.")
@@ -397,7 +397,12 @@ It is used when `crystal-encoding-magic-comment-style' is set to `custom'."
              ("{%for%}" insts "{%end%}")
              ("{%if%}" if-macro-body "{%end%}")
              ("{%unless%}" insts "{%end%}")
-             ("case"  cases "end"))
+             ("case"  cases "end")
+             ("lib" insts "end")
+             ("struct" insts "end")
+             ("enum" insts "end")
+             ("fun" insts "end")
+             ("type" insts "end"))
        ;;(macro-cmd (inst) (forexp))
        ;;(macro-cmds (macro-cmd) (macro-cmds ";" macro-cmds))
        ;;(macro-start ("{%" macro-cmd "%}"))
@@ -723,7 +728,8 @@ It is used when `crystal-encoding-magic-comment-style' is set to `custom'."
                            "while" "until" "unless" "macro"
                            "if" "then" "elsif" "else" "when" "{%if%}"
                            "{%elsif%}" "{%else%}" "{%unless%}"
-                           "rescue" "ensure" "{")
+                           "rescue" "ensure" "{"
+                           "lib" "struct" "enum" "fun" "type")
        ;; (message "Still got this one %s" (smie-indent--parent))
        (smie-rule-parent crystal-indent-level))
       ;; For (invalid) code between switch and case.
@@ -2195,7 +2201,12 @@ See `font-lock-syntax-table'.")
           "until"
           "when"
           "while"
-          "yield")
+          "yield"
+          "lib"
+          "struct"
+          "enum"
+          "fun"
+          "type")
         'symbols))
      (1 font-lock-keyword-face))
     ;; Core methods that have required arguments.


### PR DESCRIPTION
These changes add the keywords related to writing C bindings. See https://crystal-lang.org/docs/syntax_and_semantics/c_bindings/index.html.